### PR TITLE
Access record duration

### DIFF
--- a/desktop/plugins/org.eclipse.vtp.modules.interactive.ui/src/main/java/org/eclipse/vtp/modules/interactive/ui/RecordInformationProvider.java
+++ b/desktop/plugins/org.eclipse.vtp.modules.interactive.ui/src/main/java/org/eclipse/vtp/modules/interactive/ui/RecordInformationProvider.java
@@ -142,6 +142,12 @@ public class RecordInformationProvider extends PrimitiveInformationProvider impl
 					Variable dtmf = new Variable("RecordDTMF", ft);
 					VariableHelper.buildObjectFields(dtmf, bos);
 					ret.add(dtmf);
+					Variable duration = new Variable("RecordDuration", ft);
+					VariableHelper.buildObjectFields(duration, bos);
+					ret.add(duration);
+					Variable size = new Variable("RecordSize", ft);
+					VariableHelper.buildObjectFields(size, bos);
+					ret.add(size);
 				}
 			}
 			return ret;

--- a/framework/plugins/org.eclipse.vtp.framework.interactions.core/src/main/java/org/eclipse/vtp/framework/interactions/core/actions/DataRequestAction.java
+++ b/framework/plugins/org.eclipse.vtp.framework.interactions.core/src/main/java/org/eclipse/vtp/framework/interactions/core/actions/DataRequestAction.java
@@ -98,6 +98,12 @@ public class DataRequestAction implements IAction
 				IStringObject dtmfVar = (IStringObject)variableRegistry.createVariable(IStringObject.TYPE_NAME);
 				dtmfVar.setValue(context.getParameter(configuration.getDataName() + "_termchar"));
 				variableRegistry.setVariable("RecordDTMF", dtmfVar);
+				IStringObject durationVar = (IStringObject)variableRegistry.createVariable(IStringObject.TYPE_NAME);
+				durationVar.setValue(context.getParameter(configuration.getDataName() + "_duration"));
+				variableRegistry.setVariable("RecordDuration", durationVar);
+				IStringObject sizeVar = (IStringObject)variableRegistry.createVariable(IStringObject.TYPE_NAME);
+				sizeVar.setValue(context.getParameter(configuration.getDataName() + "_size"));
+				variableRegistry.setVariable("RecordSize", sizeVar);
 				lastResult.clear();
 				String lastResultXML = context.getParameter("lastresult");
 				if(lastResultXML != null && !lastResultXML.equals(""))

--- a/framework/plugins/org.eclipse.vtp.framework.interactions.voice/src/main/java/org/eclipse/vtp/framework/interactions/voice/services/VoicePlatform.java
+++ b/framework/plugins/org.eclipse.vtp.framework.interactions.voice/src/main/java/org/eclipse/vtp/framework/interactions/voice/services/VoicePlatform.java
@@ -1057,18 +1057,22 @@ public class VoicePlatform extends AbstractPlatform implements VXMLConstants
 		prompt.setLanguage(getCurrentLocale());
 		recording.setPrompt(prompt);
 		String[] parameterNames = dataRequestCommand.getParameterNames();
-		String[] submitVars = new String[parameterNames.length + 4];
+		String[] submitVars = new String[parameterNames.length + 6];
 		submitVars[0] = dataRequestCommand.getDataName();
 		submitVars[1] = dataRequestCommand.getResultName();
 		submitVars[2] = dataRequestCommand.getDataName() + "_termchar";
-		submitVars[3] = "lastresult";
+		submitVars[3] = dataRequestCommand.getDataName() + "_duration";
+		submitVars[4] = dataRequestCommand.getDataName() + "_size";
+		submitVars[5] = "lastresult";
 		Filled filled = new Filled();
 		filled.addVariable(new Variable(dataRequestCommand.getResultName(), "'"
 				+ dataRequestCommand.getFilledResultValue() + "'"));
 		filled.addVariable(new Variable(dataRequestCommand.getDataName() + "_termchar", dataRequestCommand.getDataName() + "$.termchar"));
+		filled.addVariable(new Variable(dataRequestCommand.getDataName() + "_duration", dataRequestCommand.getDataName() + "$.duration"));
+		filled.addVariable(new Variable(dataRequestCommand.getDataName() + "_size", dataRequestCommand.getDataName() + "$.size"));
 		for (int i = 0; i < parameterNames.length; ++i)
 		{
-			submitVars[i + 4] = parameterNames[i];
+			submitVars[i + 6] = parameterNames[i];
 			String[] values = dataRequestCommand
 					.getParameterValues(parameterNames[i]);
 			StringBuffer buf = new StringBuffer();


### PR DESCRIPTION
[//]: * (If not ready for merging, indicate the reason after the # on the next line.)
#
#### Card(s)
[//]: * (Link to the PivotalTracker or LeanKit cards.)
- [From BlackFlag | VIS saves empty namefile after no input](https://www.pivotaltracker.com/story/show/168030075)

#### Changes Made
1. Changes to get access to the shadow variables of record element in DataRequestForm VXML form.
2. Changes to send the shadow variables to UI (call flow projects)

#### Test Procedure
[//]: * (Use Cucumber format, if possible.)
```
Scenario:
Given: I have called contact center
And: Chose ASAP or schedule callback and entered my contact number
When: recording I stay silent and ended the recording before maximum record time breached.
Then: the name file is not created.
```
