### PR TITLE
removing the server status dependancy to log the missing prompts

### DIFF
--- a/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.engine/src/main/java/org/eclipse/vtp/framework/engine/ResourceGroup.java
+++ b/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.engine/src/main/java/org/eclipse/vtp/framework/engine/ResourceGroup.java
@@ -151,17 +151,8 @@ public class ResourceGroup implements IResourceManager,
 									break;
 								} catch (Exception e) {
 									if (logging == ExternalServerManager.Logging.ALWAYS || (logging == ExternalServerManager.Logging.FIRSTFAILURE && bundleList.get(ResourceGroup.this.bundle.getHeaders().get("Bundle-Name")))){
-										switch (logging) {
-										case FIRSTFAILURE:
-											if (!server.lastStatus()) {
-												break;
-											}
-										case ALWAYS:
-											System.out
-													.println("Unable to connect to external media server @ "
-															+ location);
-											e.printStackTrace();
-										}
+										System.out.println("Unable to connect to external media server @ "+ location);
+										e.printStackTrace();
 									}
 									server.setStatus(false);
 								}


### PR DESCRIPTION
[//]: * (If not ready for merging, indicate the reason after the # on the next line.)
#
#### Card(s)
[//]: * (Link to the PivotalTracker or LeanKit cards.)
- [Logging for missing prompt sets not obeying the toolkit.settings](https://www.pivotaltracker.com/story/show/147221291)

#### Changes Made
1. Removed the dependency of server status for logging missing prompts as we are logging them based on language bundle status.
