### PR TITLE
Missing prompts

### DIFF
--- a/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.engine/src/main/java/org/eclipse/vtp/framework/engine/ResourceGroup.java
+++ b/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.engine/src/main/java/org/eclipse/vtp/framework/engine/ResourceGroup.java
@@ -165,8 +165,8 @@ public class ResourceGroup implements IResourceManager,
 												.getHeaders()
 												.get("Bundle-Name")
 										+ " from any external media servers");
-								bundleList.put(ResourceGroup.this.bundle.getHeaders().get("Bundle-Name"), false);
 							}
+							bundleList.put(ResourceGroup.this.bundle.getHeaders().get("Bundle-Name"), false);
 						}
 						try {
 							synchronized (lock) {

--- a/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.engine/src/main/java/org/eclipse/vtp/framework/engine/ResourceGroup.java
+++ b/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.engine/src/main/java/org/eclipse/vtp/framework/engine/ResourceGroup.java
@@ -150,7 +150,8 @@ public class ResourceGroup implements IResourceManager,
 									server.setStatus(true);
 									break;
 								} catch (Exception e) {
-									if (logging == ExternalServerManager.Logging.ALWAYS || (logging == ExternalServerManager.Logging.FIRSTFAILURE && bundleList.get(ResourceGroup.this.bundle.getHeaders().get("Bundle-Name")))){
+									if (logging == ExternalServerManager.Logging.ALWAYS || 
+											(logging == ExternalServerManager.Logging.FIRSTFAILURE && bundleList.get(ResourceGroup.this.bundle.getHeaders().get("Bundle-Name"))&& !connected)){
 										System.out.println("Unable to connect to external media server @ "+ location);
 										e.printStackTrace();
 									}


### PR DESCRIPTION
[//]: * (If not ready for merging, indicate the reason after the # on the next line.)
#
#### Card(s)
[//]: * (Link to the PivotalTracker or LeanKit cards.)
- [Logging for missing prompt sets not obeying the toolkit.settings](https://www.pivotaltracker.com/story/show/147221291)


#### Changes Made
1. Disabled logging when one iteration of searching is completed through available media servers.
2. Disabled further logging if the voice set is found in any of the media servers in the first iteration of searching.


