### PR TITLE
Configurable transfer type

### DIFF
--- a/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.modules.interactive.ui/src/main/java/org/eclipse/vtp/modules/interactive/ui/properties/AdvancedTransferGeneralPropertiesPanel.java
+++ b/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.modules.interactive.ui/src/main/java/org/eclipse/vtp/modules/interactive/ui/properties/AdvancedTransferGeneralPropertiesPanel.java
@@ -176,7 +176,6 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 		transferExprComp.setLayout(layout);
 		transferExpr = new Text(transferExprComp, SWT.SINGLE | SWT.BORDER);
 		transferExpr.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-//		transferLayout.topControl = transferExprComp;
 		transferComp.layout();
 
 		Label valueLabel = new Label(comp, SWT.NONE);
@@ -272,7 +271,6 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 	}
 	
 	private void transferTypeChanged() {
-		System.out.println("Transfer listener" + transferType.getSelectionIndex());
 		switch (transferType.getSelectionIndex()){
 		case 3:
 			transferLayout.topControl = transferExprComp;
@@ -295,7 +293,6 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 	@Override
 	public void setConfigurationContext(Map<String, Object> values) {
 		if (!(currentBrand == null)) {
-			System.out.println("setting changes");
 			storeBindings();
 		}
 
@@ -370,9 +367,7 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 		if (transferPropertyItem == null) {
 			transferPropertyItem = new PropertyBindingItem();
 		}
-		if ("variable".equalsIgnoreCase(transferPropertyItem.getValue())) {
-			transferTypeIndex = 2;
-		} else if ("expression".equalsIgnoreCase(transferPropertyItem.getValue())) {
+		if ("expression".equalsIgnoreCase(transferPropertyItem.getValue())) {
 			transferTypeIndex = 3;
 		}
 		transferType.select(transferTypeIndex);
@@ -416,7 +411,6 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 		if (transferTypePropertyItem == null) {
 			transferTypePropertyItem = new PropertyBindingItem();
 		}
-		System.out.println("in setConfigurationContext: "+transferTypePropertyItem.getValue());
 		if (transferTypePropertyItem.getValue() != null) {
 			if (transferTypePropertyItem.getValue().equals("bridge")) {
 				transferType.select(1);
@@ -447,7 +441,6 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 	public void save() {
 		try {
 			getElement().setName(nameField.getText());
-			System.out.println("saving changes");
 			storeBindings();
 			getElement().commitConfigurationChanges(bindingManager);
 		} catch (Exception ex) {
@@ -608,7 +601,6 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 				transferTypePropertyItem = (PropertyBindingItem) transferTypePropertyItem
 						.clone();
 			}
-			System.out.println("in storebinding: "+transferType.getSelectionIndex());
 			switch (transferType.getSelectionIndex()) {
 			case (1):
 				transferTypePropertyItem.setValue("bridge");
@@ -618,30 +610,30 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 				break;
 			case (3):
 				transferTypePropertyItem.setExpression(transferExpr.getText());
-//				transferTypePropertyItem.setValue(transferExpr.getText());
-				System.out.println(transferTypePropertyItem.getValue());
 				break;
 			default:
 				transferTypePropertyItem.setValue("blind");
-				System.out.println("default: "+ transferTypePropertyItem.getValue());
 				break;
 			}
 			brandBinding.setBindingItem(transferTypePropertyItem);
+
+			namedBinding = interactionBinding.getNamedBinding("transfer-type");
+			languageBinding = namedBinding.getLanguageBinding(currentLanguage);
+			brandBinding = languageBinding.getBrandBinding(currentBrand);
 			if(transferType.getSelectionIndex() == 3){
-				namedBinding = interactionBinding.getNamedBinding("transfer-type");
-				languageBinding = namedBinding.getLanguageBinding(currentLanguage);
-				brandBinding = languageBinding.getBrandBinding(currentBrand);
 				type = "expression";
-				typePropertyItem = (PropertyBindingItem) brandBinding.getBindingItem();
-				if (typePropertyItem == null) {
-					typePropertyItem = new PropertyBindingItem();
-				} else {
-					typePropertyItem = (PropertyBindingItem) typePropertyItem
-							.clone();
-				}
-				typePropertyItem.setValue(type);
-				brandBinding.setBindingItem(typePropertyItem);
+			}else{
+				type = "static";
 			}
+			typePropertyItem = (PropertyBindingItem) brandBinding.getBindingItem();
+			if (typePropertyItem == null) {
+				typePropertyItem = new PropertyBindingItem();
+			} else {
+				typePropertyItem = (PropertyBindingItem) typePropertyItem
+						.clone();
+			}
+			typePropertyItem.setValue(type);
+			brandBinding.setBindingItem(typePropertyItem);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 		}

--- a/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.modules.interactive.ui/src/main/java/org/eclipse/vtp/modules/interactive/ui/properties/AdvancedTransferGeneralPropertiesPanel.java
+++ b/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.modules.interactive.ui/src/main/java/org/eclipse/vtp/modules/interactive/ui/properties/AdvancedTransferGeneralPropertiesPanel.java
@@ -353,24 +353,24 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 		}
 		destinationType.select(typeIndex);
 		
-		int transferTypeIndex = 0;
-		namedBinding = interactionBinding.getNamedBinding("transfer-type");
-		if (namedBinding.getLanguageBinding(currentLanguage)
-				.getBrandBinding(currentBrand).getBindingItem() == null) {
-			languageBinding = namedBinding.getLanguageBinding("");
-		} else {
-			languageBinding = namedBinding.getLanguageBinding(currentLanguage);
-		}
-		brandBinding = languageBinding.getBrandBinding(currentBrand);
-		PropertyBindingItem transferPropertyItem = (PropertyBindingItem) brandBinding
-				.getBindingItem();
-		if (transferPropertyItem == null) {
-			transferPropertyItem = new PropertyBindingItem();
-		}
-		if ("expression".equalsIgnoreCase(transferPropertyItem.getValue())) {
-			transferTypeIndex = 3;
-		}
-		transferType.select(transferTypeIndex);
+//		int transferTypeIndex = 0;
+//		namedBinding = interactionBinding.getNamedBinding("transfer-type");
+//		if (namedBinding.getLanguageBinding(currentLanguage)
+//				.getBrandBinding(currentBrand).getBindingItem() == null) {
+//			languageBinding = namedBinding.getLanguageBinding("");
+//		} else {
+//			languageBinding = namedBinding.getLanguageBinding(currentLanguage);
+//		}
+//		brandBinding = languageBinding.getBrandBinding(currentBrand);
+//		PropertyBindingItem transferPropertyItem = (PropertyBindingItem) brandBinding
+//				.getBindingItem();
+//		if (transferPropertyItem == null) {
+//			transferPropertyItem = new PropertyBindingItem();
+//		}
+//		if ("expression".equalsIgnoreCase(transferPropertyItem.getValue())) {
+//			transferTypeIndex = 3;
+//		}
+//		transferType.select(transferTypeIndex);
 		
 		namedBinding = interactionBinding.getNamedBinding("destination");
 		if (namedBinding.getLanguageBinding(currentLanguage)
@@ -617,23 +617,23 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 			}
 			brandBinding.setBindingItem(transferTypePropertyItem);
 
-			namedBinding = interactionBinding.getNamedBinding("transfer-type");
-			languageBinding = namedBinding.getLanguageBinding(currentLanguage);
-			brandBinding = languageBinding.getBrandBinding(currentBrand);
-			if(transferType.getSelectionIndex() == 3){
-				type = "expression";
-			}else{
-				type = "static";
-			}
-			typePropertyItem = (PropertyBindingItem) brandBinding.getBindingItem();
-			if (typePropertyItem == null) {
-				typePropertyItem = new PropertyBindingItem();
-			} else {
-				typePropertyItem = (PropertyBindingItem) typePropertyItem
-						.clone();
-			}
-			typePropertyItem.setValue(type);
-			brandBinding.setBindingItem(typePropertyItem);
+//			namedBinding = interactionBinding.getNamedBinding("transfer-type");
+//			languageBinding = namedBinding.getLanguageBinding(currentLanguage);
+//			brandBinding = languageBinding.getBrandBinding(currentBrand);
+//			if(transferType.getSelectionIndex() == 3){
+//				type = "expression";
+//			}else{
+//				type = "static";
+//			}
+//			typePropertyItem = (PropertyBindingItem) brandBinding.getBindingItem();
+//			if (typePropertyItem == null) {
+//				typePropertyItem = new PropertyBindingItem();
+//			} else {
+//				typePropertyItem = (PropertyBindingItem) typePropertyItem
+//						.clone();
+//			}
+//			typePropertyItem.setValue(type);
+//			brandBinding.setBindingItem(typePropertyItem);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 		}

--- a/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.modules.interactive.ui/src/main/java/org/eclipse/vtp/modules/interactive/ui/properties/AdvancedTransferGeneralPropertiesPanel.java
+++ b/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.modules.interactive.ui/src/main/java/org/eclipse/vtp/modules/interactive/ui/properties/AdvancedTransferGeneralPropertiesPanel.java
@@ -353,25 +353,6 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 		}
 		destinationType.select(typeIndex);
 		
-//		int transferTypeIndex = 0;
-//		namedBinding = interactionBinding.getNamedBinding("transfer-type");
-//		if (namedBinding.getLanguageBinding(currentLanguage)
-//				.getBrandBinding(currentBrand).getBindingItem() == null) {
-//			languageBinding = namedBinding.getLanguageBinding("");
-//		} else {
-//			languageBinding = namedBinding.getLanguageBinding(currentLanguage);
-//		}
-//		brandBinding = languageBinding.getBrandBinding(currentBrand);
-//		PropertyBindingItem transferPropertyItem = (PropertyBindingItem) brandBinding
-//				.getBindingItem();
-//		if (transferPropertyItem == null) {
-//			transferPropertyItem = new PropertyBindingItem();
-//		}
-//		if ("expression".equalsIgnoreCase(transferPropertyItem.getValue())) {
-//			transferTypeIndex = 3;
-//		}
-//		transferType.select(transferTypeIndex);
-		
 		namedBinding = interactionBinding.getNamedBinding("destination");
 		if (namedBinding.getLanguageBinding(currentLanguage)
 				.getBrandBinding(currentBrand).getBindingItem() == null) {
@@ -616,24 +597,6 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 				break;
 			}
 			brandBinding.setBindingItem(transferTypePropertyItem);
-
-//			namedBinding = interactionBinding.getNamedBinding("transfer-type");
-//			languageBinding = namedBinding.getLanguageBinding(currentLanguage);
-//			brandBinding = languageBinding.getBrandBinding(currentBrand);
-//			if(transferType.getSelectionIndex() == 3){
-//				type = "expression";
-//			}else{
-//				type = "static";
-//			}
-//			typePropertyItem = (PropertyBindingItem) brandBinding.getBindingItem();
-//			if (typePropertyItem == null) {
-//				typePropertyItem = new PropertyBindingItem();
-//			} else {
-//				typePropertyItem = (PropertyBindingItem) typePropertyItem
-//						.clone();
-//			}
-//			typePropertyItem.setValue(type);
-//			brandBinding.setBindingItem(typePropertyItem);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 		}

--- a/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.modules.interactive.ui/src/main/java/org/eclipse/vtp/modules/interactive/ui/properties/AdvancedTransferGeneralPropertiesPanel.java
+++ b/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.modules.interactive.ui/src/main/java/org/eclipse/vtp/modules/interactive/ui/properties/AdvancedTransferGeneralPropertiesPanel.java
@@ -603,16 +603,16 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 			}
 			switch (transferType.getSelectionIndex()) {
 			case (1):
-				transferTypePropertyItem.setValue("bridge");
+				transferTypePropertyItem.setStaticValue("bridge");
 				break;
 			case (2):
-				transferTypePropertyItem.setValue("consultation");
+				transferTypePropertyItem.setStaticValue("consultation");
 				break;
 			case (3):
 				transferTypePropertyItem.setExpression(transferExpr.getText());
 				break;
 			default:
-				transferTypePropertyItem.setValue("blind");
+				transferTypePropertyItem.setStaticValue("blind");
 				break;
 			}
 			brandBinding.setBindingItem(transferTypePropertyItem);

--- a/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.modules.interactive.ui/src/main/java/org/eclipse/vtp/modules/interactive/ui/properties/AdvancedTransferGeneralPropertiesPanel.java
+++ b/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.modules.interactive.ui/src/main/java/org/eclipse/vtp/modules/interactive/ui/properties/AdvancedTransferGeneralPropertiesPanel.java
@@ -355,6 +355,28 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 			typeIndex = 1;
 		}
 		destinationType.select(typeIndex);
+		
+		int transferTypeIndex = 0;
+		namedBinding = interactionBinding.getNamedBinding("transfer-type");
+		if (namedBinding.getLanguageBinding(currentLanguage)
+				.getBrandBinding(currentBrand).getBindingItem() == null) {
+			languageBinding = namedBinding.getLanguageBinding("");
+		} else {
+			languageBinding = namedBinding.getLanguageBinding(currentLanguage);
+		}
+		brandBinding = languageBinding.getBrandBinding(currentBrand);
+		PropertyBindingItem transferPropertyItem = (PropertyBindingItem) brandBinding
+				.getBindingItem();
+		if (transferPropertyItem == null) {
+			transferPropertyItem = new PropertyBindingItem();
+		}
+		if ("variable".equalsIgnoreCase(transferPropertyItem.getValue())) {
+			transferTypeIndex = 2;
+		} else if ("expression".equalsIgnoreCase(transferPropertyItem.getValue())) {
+			transferTypeIndex = 3;
+		}
+		transferType.select(transferTypeIndex);
+		
 		namedBinding = interactionBinding.getNamedBinding("destination");
 		if (namedBinding.getLanguageBinding(currentLanguage)
 				.getBrandBinding(currentBrand).getBindingItem() == null) {
@@ -606,7 +628,7 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 			}
 			brandBinding.setBindingItem(transferTypePropertyItem);
 			if(transferType.getSelectionIndex() == 3){
-				namedBinding = interactionBinding.getNamedBinding("type");
+				namedBinding = interactionBinding.getNamedBinding("transfer-type");
 				languageBinding = namedBinding.getLanguageBinding(currentLanguage);
 				brandBinding = languageBinding.getBrandBinding(currentBrand);
 				type = "expression";

--- a/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.modules.interactive.ui/src/main/java/org/eclipse/vtp/modules/interactive/ui/properties/AdvancedTransferGeneralPropertiesPanel.java
+++ b/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.modules.interactive.ui/src/main/java/org/eclipse/vtp/modules/interactive/ui/properties/AdvancedTransferGeneralPropertiesPanel.java
@@ -605,6 +605,21 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 				break;
 			}
 			brandBinding.setBindingItem(transferTypePropertyItem);
+			if(transferType.getSelectionIndex() == 3){
+				namedBinding = interactionBinding.getNamedBinding("type");
+				languageBinding = namedBinding.getLanguageBinding(currentLanguage);
+				brandBinding = languageBinding.getBrandBinding(currentBrand);
+				type = "expression";
+				typePropertyItem = (PropertyBindingItem) brandBinding.getBindingItem();
+				if (typePropertyItem == null) {
+					typePropertyItem = new PropertyBindingItem();
+				} else {
+					typePropertyItem = (PropertyBindingItem) typePropertyItem
+							.clone();
+				}
+				typePropertyItem.setValue(type);
+				brandBinding.setBindingItem(typePropertyItem);
+			}
 		} catch (Exception ex) {
 			ex.printStackTrace();
 		}

--- a/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.modules.interactive.ui/src/main/java/org/eclipse/vtp/modules/interactive/ui/properties/AdvancedTransferGeneralPropertiesPanel.java
+++ b/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.modules.interactive.ui/src/main/java/org/eclipse/vtp/modules/interactive/ui/properties/AdvancedTransferGeneralPropertiesPanel.java
@@ -595,7 +595,8 @@ public class AdvancedTransferGeneralPropertiesPanel extends
 				transferTypePropertyItem.setValue("consultation");
 				break;
 			case (3):
-				transferTypePropertyItem.setValue(transferExpr.getText());
+				transferTypePropertyItem.setExpression(transferExpr.getText());
+//				transferTypePropertyItem.setValue(transferExpr.getText());
 				System.out.println(transferTypePropertyItem.getValue());
 				break;
 			default:


### PR DESCRIPTION
[//]: * (If not ready for merging, indicate the reason after the # on the next line.)
#
#### Card(s)
[//]: * (Link to the PivotalTracker or LeanKit cards.)
- [OpenVXML changes  to read the transfer type from toolkit properties](https://www.pivotaltracker.com/story/show/178499333)

#### Changes Made
1. Changes made in org.eclipse.vtp.modules.interactive.ui.properties.AdvancedTransferGeneralPropertiesPanel.java to add an additional item "expression" in "Transfer Type" dropdown. Which when selected, provides a script box to enter **executable script**. 
