### PR TITLE
Cvs 5571 CVS-5571 CVS-5606 Implemented the changes for avoiding XXS attacks

### DIFF
--- a/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.desktop.export/META-INF/MANIFEST.MF
+++ b/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.desktop.export/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.vtp.framework.util;bundle-version="6.0.0",
  com.openmethods.openvxml.desktop.model.branding;bundle-version="6.0.0",
  com.openmethods.openvxml.desktop.model.businessobjects;bundle-version="6.0.0",
- com.openmethods.openvxml.desktop.model.workflow;bundle-version="6.0.0"
+ com.openmethods.openvxml.desktop.model.workflow;bundle-version="6.0.0",
+ org.apache.commons.lang3;bundle-version="3.1.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.eclipse.ui,

--- a/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.desktop.export/src/main/resources/index.jsp
+++ b/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.desktop.export/src/main/resources/index.jsp
@@ -40,7 +40,7 @@ public void printDir(String prefix, File dir, PrintWriter out)
 		}
 		else
 		{
-			out.println(prefix + "/" + StringEscapeUtils.escapeHtml4(dir.getName()) + "/" + child.getName());
+			out.println(prefix + "/" + StringEscapeUtils.escapeHtml4(dir.getName()) + "/" + StringEscapeUtils.escapeHtml4(child.getName()));
 		}
 	}
 }

--- a/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.desktop.export/src/main/resources/index.jsp
+++ b/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.desktop.export/src/main/resources/index.jsp
@@ -31,7 +31,7 @@ response.flushBuffer();
 <%! 
 public void printDir(String prefix, File dir, PrintWriter out)
 {
-	out.println(prefix + "/" + dir.getName() + "/");
+	out.println(prefix + "/" + StringEscapeUtils.escapeHtml4(dir.getName()) + "/");
 	for(File child : dir.listFiles())
 	{
 		if(child.isDirectory())

--- a/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.desktop.export/src/main/resources/index.jsp
+++ b/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.desktop.export/src/main/resources/index.jsp
@@ -1,5 +1,5 @@
 <%@ page language="java" contentType="text/plain; charset=ISO-8859-1"
-    pageEncoding="ISO-8859-1" import="java.io.File,java.io.PrintWriter"%>
+    pageEncoding="ISO-8859-1" import="java.io.File,java.io.PrintWriter,org.apache.commons.lang3.StringEscapeUtils"%>
 <%
 String requestURI = request.getRequestURI();
 //System.out.println(requestURI);
@@ -36,11 +36,11 @@ public void printDir(String prefix, File dir, PrintWriter out)
 	{
 		if(child.isDirectory())
 		{
-			printDir(prefix + "/" + fn:escapeXml(dir.getName()), child, out);
+			printDir(prefix + "/" + StringEscapeUtils.escapeHtml4(dir.getName()), child, out);
 		}
 		else
 		{
-			out.println(prefix + "/" + fn:escapeXml(dir.getName()) + "/" + child.getName());
+			out.println(prefix + "/" + StringEscapeUtils.escapeHtml4(dir.getName()) + "/" + child.getName());
 		}
 	}
 }

--- a/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.desktop.export/src/main/resources/index.jsp
+++ b/com.vht.openvxml.desktop/com.vht.openvxml.desktop.plugins/org.eclipse.vtp.desktop.export/src/main/resources/index.jsp
@@ -36,11 +36,11 @@ public void printDir(String prefix, File dir, PrintWriter out)
 	{
 		if(child.isDirectory())
 		{
-			printDir(prefix + "/" + dir.getName(), child, out);
+			printDir(prefix + "/" + fn:escapeXml(dir.getName()), child, out);
 		}
 		else
 		{
-			out.println(prefix + "/" + dir.getName() + "/" + child.getName());
+			out.println(prefix + "/" + fn:escapeXml(dir.getName()) + "/" + child.getName());
 		}
 	}
 }


### PR DESCRIPTION
[//]: * (If not ready for merging, indicate the reason after the # on the next line.)
#
#### Card(s)
[//]: * (Link to the PivotalTracker or LeanKit cards.)
- [CVS-5571](https://jira.vhtops.net/browse/CVS-5571) Stored_XSS @ index.jsp
- [CVS-5606](https://jira.vhtops.net/browse/CVS-5606) Stored_XSS @ index.jsp

#### Changes Made
1. Utilized StringEscapeUtils.escapeHtml4 function of org.apache.commons.lang3 in order to avoid XXS attacks in JSP.

#### Test Procedure
[//]: * (Use Cucumber format, if possible.)

Scenario:
Given:

1. Try to insert an script expression like --> <script>alert('')</script> and access this data from browser.
2. Then no alert should pop up on accessing effected page (/org.eclipse.vtp.desktop.export/src/main/resources/index.jsp)

```
