### PR TITLE
CVS-7281 Improper_Restriction_of_XXE_Ref in WebServiceCallAction.java

### DIFF
--- a/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.webservices/src/main/java/org/eclipse/vtp/framework/webservices/actions/WebServiceCallAction.java
+++ b/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.webservices/src/main/java/org/eclipse/vtp/framework/webservices/actions/WebServiceCallAction.java
@@ -23,6 +23,7 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
@@ -160,6 +161,9 @@ public class WebServiceCallAction implements IAction {
 					factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
 					factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 					factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+					factory.setFeature(XMLConstants.ACCESS_EXTERNAL_DTD, false);
+					factory.setFeature(XMLConstants.ACCESS_EXTERNAL_SCHEMA, false);
+					factory.setFeature(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, false);
 					factory.setXIncludeAware(false);
 					factory.setExpandEntityReferences(false);
 					DocumentBuilder builder = factory.newDocumentBuilder();


### PR DESCRIPTION
[//]: * (If not ready for merging, indicate the reason after the # on the next line.)
#
#### Card(s)
[//]: * (Link to the PivotalTracker or LeanKit cards.)
- [Improper_Restriction_of_XXE_Ref in WebServiceCallAction.java](https://jira.vhtops.net/browse/CVS-7281)

#### Related Pull Requests
[//]: * (List pull requests that must be merged before this one.)
- N/A

#### Changes Made
1. Added the 3 lines of code per the suggestion within Checkmarx
[Checkmarx: Improper Restriction of XXE Ref](https://ast.checkmarx.net/results/87614d9f-e9eb-4647-9541-e2ba342bfc21/69538ccd-a742-4a8d-aff9-873706781845/sast?result-id=8kwHRKTmevdlkeB%2BfuM6%2FTfz%2BQY%3D&redirect=true)

#### Test Procedure
Normal VIS regression to determine normal functionality. 
