### PR TITLE
OPC-1507 | Genesys XXE Vulnerability

### DIFF
--- a/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.interactions.core/src/main/java/org/eclipse/vtp/framework/interactions/core/actions/DataRequestAction.java
+++ b/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.interactions.core/src/main/java/org/eclipse/vtp/framework/interactions/core/actions/DataRequestAction.java
@@ -17,7 +17,7 @@ import java.math.BigDecimal;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
-import javax.xml.parsers.DocumentBuilderFactory;
+import org.eclipse.vtp.framework.util.XMLUtilities;
 
 import org.eclipse.vtp.framework.common.ILastResult;
 import org.eclipse.vtp.framework.common.IStringObject;
@@ -119,9 +119,8 @@ public class DataRequestAction implements IAction {
 				if (lastResultXML != null && !lastResultXML.equals("")) {
 					Document lastResultDocument = null;
 					try {
-						lastResultDocument = DocumentBuilderFactory
-								.newInstance()
-								.newDocumentBuilder()
+						lastResultDocument = XMLUtilities
+								.getDocumentBuilder()
 								.parse(new ByteArrayInputStream(lastResultXML
 										.getBytes()));
 					} catch (Exception ex) {
@@ -202,9 +201,8 @@ public class DataRequestAction implements IAction {
 				if (lastResultXML != null && !lastResultXML.equals("")) {
 					Document lastResultDocument = null;
 					try {
-						lastResultDocument = DocumentBuilderFactory
-								.newInstance()
-								.newDocumentBuilder()
+						lastResultDocument = XMLUtilities
+								.getDocumentBuilder()
 								.parse(new ByteArrayInputStream(lastResultXML
 										.getBytes()));
 					} catch (Exception ex) {

--- a/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.interactions.core/src/main/java/org/eclipse/vtp/framework/interactions/core/actions/InputRequestAction.java
+++ b/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.interactions.core/src/main/java/org/eclipse/vtp/framework/interactions/core/actions/InputRequestAction.java
@@ -17,7 +17,7 @@ import java.math.BigDecimal;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
-import javax.xml.parsers.DocumentBuilderFactory;
+import org.eclipse.vtp.framework.util.XMLUtilities;
 
 import org.eclipse.vtp.framework.common.ILastResult;
 import org.eclipse.vtp.framework.common.IStringObject;
@@ -112,9 +112,8 @@ public class InputRequestAction implements IAction {
 				if (lastResultXML != null && !lastResultXML.equals("")) {
 					Document lastResultDocument = null;
 					try {
-						lastResultDocument = DocumentBuilderFactory
-								.newInstance()
-								.newDocumentBuilder()
+						lastResultDocument = XMLUtilities
+								.getDocumentBuilder()
 								.parse(new ByteArrayInputStream(lastResultXML
 										.getBytes()));
 					} catch (Exception ex) {
@@ -195,9 +194,8 @@ public class InputRequestAction implements IAction {
 				String lastResultXML = context.getParameter("lastresult");
 				Document lastResultDocument = null;
 				try {
-					lastResultDocument = DocumentBuilderFactory
-							.newInstance()
-							.newDocumentBuilder()
+					lastResultDocument = XMLUtilities
+							.getDocumentBuilder()
 							.parse(new ByteArrayInputStream(lastResultXML
 									.getBytes()));
 				} catch (Exception ex) {

--- a/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.interactions.core/src/main/java/org/eclipse/vtp/framework/interactions/core/actions/SelectionRequestAction.java
+++ b/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.interactions.core/src/main/java/org/eclipse/vtp/framework/interactions/core/actions/SelectionRequestAction.java
@@ -17,7 +17,7 @@ import java.math.BigDecimal;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
-import javax.xml.parsers.DocumentBuilderFactory;
+import org.eclipse.vtp.framework.util.XMLUtilities;
 
 import org.eclipse.vtp.framework.common.ILastResult;
 import org.eclipse.vtp.framework.common.IStringObject;
@@ -106,9 +106,8 @@ public class SelectionRequestAction implements IAction {
 				if (lastResultXML != null && !lastResultXML.equals("")) {
 					Document lastResultDocument = null;
 					try {
-						lastResultDocument = DocumentBuilderFactory
-								.newInstance()
-								.newDocumentBuilder()
+						lastResultDocument = XMLUtilities
+								.getDocumentBuilder()
 								.parse(new ByteArrayInputStream(lastResultXML
 										.getBytes()));
 					} catch (Exception ex) {
@@ -163,9 +162,8 @@ public class SelectionRequestAction implements IAction {
 				if (lastResultXML != null && !lastResultXML.equals("")) {
 					Document lastResultDocument = null;
 					try {
-						lastResultDocument = DocumentBuilderFactory
-								.newInstance()
-								.newDocumentBuilder()
+						lastResultDocument = XMLUtilities
+								.getDocumentBuilder()
 								.parse(new ByteArrayInputStream(lastResultXML
 										.getBytes()));
 					} catch (Exception ex) {

--- a/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.util/src/main/java/org/eclipse/vtp/framework/util/XMLUtilities.java
+++ b/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.util/src/main/java/org/eclipse/vtp/framework/util/XMLUtilities.java
@@ -486,6 +486,21 @@ public class XMLUtilities {
 			throws ParserConfigurationException {
 		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory
 				.newInstance();
+		// Harden the parser against XML External Entity (XXE) attacks
+		// (CWE-611). This utility is shared across the framework, so any caller
+		// that parses untrusted XML (e.g. Genesys attached data) inherits a
+		// safe-by-default parser. See the OWASP XXE Prevention Cheat Sheet.
+		documentBuilderFactory.setFeature(
+				"http://apache.org/xml/features/disallow-doctype-decl", true);
+		documentBuilderFactory.setFeature(
+				"http://xml.org/sax/features/external-general-entities", false);
+		documentBuilderFactory.setFeature(
+				"http://xml.org/sax/features/external-parameter-entities", false);
+		documentBuilderFactory.setFeature(
+				"http://apache.org/xml/features/nonvalidating/load-external-dtd",
+				false);
+		documentBuilderFactory.setXIncludeAware(false);
+		documentBuilderFactory.setExpandEntityReferences(false);
 
 		return documentBuilderFactory.newDocumentBuilder();
 	}

--- a/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.util/src/main/java/org/eclipse/vtp/framework/util/XMLUtilities.java
+++ b/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.util/src/main/java/org/eclipse/vtp/framework/util/XMLUtilities.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
+import java.util.logging.Logger;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -28,7 +29,9 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 /**
  * Static utility class that hosts functions that make dealing with xml
@@ -477,19 +480,30 @@ public class XMLUtilities {
 	}
 
 	/**
-	 * Convenience function to get a DOM document builder object.
-	 * 
-	 * @return A new <code>DocumentBuilder</code> instance.
-	 * @throws ParserConfigurationException
+	 * Returns a namespace-unaware, XXE-hardened document builder. Equivalent to
+	 * {@link #getDocumentBuilder(boolean) getDocumentBuilder(false)}.
 	 */
 	public static DocumentBuilder getDocumentBuilder()
 			throws ParserConfigurationException {
+		return getDocumentBuilder(false);
+	}
+
+	/**
+	 * Returns the framework's shared document builder, hardened against XXE
+	 * (CWE-611); all runtime parsers of untrusted XML should obtain their builder
+	 * here. {@code disallow-doctype-decl} is the primary control; the
+	 * external-entity/DTD flags are kept as a fallback should it ever be relaxed.
+	 * {@code setExpandEntityReferences} is deliberately omitted - it is not an XXE
+	 * control and leaves EntityReference nodes that callers do not traverse.
+	 *
+	 * @param namespaceAware
+	 *            required by callers using getLocalName()/NS lookups (e.g. SOAP).
+	 */
+	public static DocumentBuilder getDocumentBuilder(boolean namespaceAware)
+			throws ParserConfigurationException {
 		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory
 				.newInstance();
-		// Harden the parser against XML External Entity (XXE) attacks
-		// (CWE-611). This utility is shared across the framework, so any caller
-		// that parses untrusted XML (e.g. Genesys attached data) inherits a
-		// safe-by-default parser. See the OWASP XXE Prevention Cheat Sheet.
+		documentBuilderFactory.setNamespaceAware(namespaceAware);
 		documentBuilderFactory.setFeature(
 				"http://apache.org/xml/features/disallow-doctype-decl", true);
 		documentBuilderFactory.setFeature(
@@ -500,10 +514,39 @@ public class XMLUtilities {
 				"http://apache.org/xml/features/nonvalidating/load-external-dtd",
 				false);
 		documentBuilderFactory.setXIncludeAware(false);
-		documentBuilderFactory.setExpandEntityReferences(false);
 
-		return documentBuilderFactory.newDocumentBuilder();
+		DocumentBuilder documentBuilder = documentBuilderFactory
+				.newDocumentBuilder();
+		// Callers swallow parse exceptions, so log DOCTYPE rejections distinctly.
+		documentBuilder.setErrorHandler(XXE_LOGGING_ERROR_HANDLER);
+		return documentBuilder;
 	}
+
+	/** Logs DOCTYPE rejections before rethrowing, since callers swallow them. */
+	private static final ErrorHandler XXE_LOGGING_ERROR_HANDLER = new ErrorHandler() {
+		private final Logger log = Logger.getLogger(XMLUtilities.class
+				.getName());
+
+		@Override
+		public void warning(SAXParseException exception) {
+		}
+
+		@Override
+		public void error(SAXParseException exception) {
+			// Non-fatal; don't throw, matching the default handler.
+		}
+
+		@Override
+		public void fatalError(SAXParseException exception)
+				throws SAXParseException {
+			String message = exception.getMessage();
+			if (message != null && message.contains("DOCTYPE")) {
+				log.warning("Rejected XML containing a DOCTYPE declaration "
+						+ "(disallowed to prevent XXE): " + message);
+			}
+			throw exception;
+		}
+	};
 
 	/**
 	 * Loads the given file using the default XML DOM implementation.

--- a/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.util/src/test/java/org/eclipse/vtp/framework/util/XMLUtilitiesXXETest.java
+++ b/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.util/src/test/java/org/eclipse/vtp/framework/util/XMLUtilitiesXXETest.java
@@ -1,0 +1,73 @@
+package org.eclipse.vtp.framework.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import javax.xml.parsers.DocumentBuilder;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXParseException;
+
+/**
+ * Verifies the XXE (CWE-611) hardening of {@link XMLUtilities}: a legitimate
+ * Genesys attached-data payload still parses, while a DOCTYPE payload is
+ * rejected. Not run by {@code mvn verify} (Tycho compiles only src/main/java);
+ * run from an IDE or with the bundled junit/hamcrest jars on the classpath.
+ */
+public class XMLUtilitiesXXETest {
+
+	/** Real-shape Genesys GetAttachedData response. */
+	private static final String LEGITIMATE = "<userdata>"
+			+ "<key name=\"CustomerSegment\" value=\"VQ_Runteam\"/>"
+			+ "<key name=\"VH_ANI\" value=\"2167025451\"/>"
+			+ "<key name=\"VH_OFFER\" value=\"1:Y\"/>" + "</userdata>";
+
+	/** Same shape, weaponized with an external-entity DOCTYPE. */
+	private static final String XXE = "<?xml version=\"1.0\"?>"
+			+ "<!DOCTYPE userdata [ <!ENTITY xxe SYSTEM \"file:///c:/windows/win.ini\"> ]>"
+			+ "<userdata><key name=\"CustomerSegment\" value=\"&xxe;\"/></userdata>";
+
+	private static Document parse(String xml) throws Exception {
+		DocumentBuilder builder = XMLUtilities.getDocumentBuilder();
+		return builder.parse(new ByteArrayInputStream(xml
+				.getBytes(StandardCharsets.UTF_8)));
+	}
+
+	@Test
+	public void legitimatePayloadStillParses() throws Exception {
+		Document doc = parse(LEGITIMATE);
+		NodeList keys = doc.getDocumentElement().getElementsByTagName("key");
+		assertEquals(3, keys.getLength());
+		assertEquals("VQ_Runteam",
+				((Element) keys.item(0)).getAttribute("value"));
+	}
+
+	@Test
+	public void doctypePayloadIsRejected() throws Exception {
+		try {
+			parse(XXE);
+			fail("Expected SAXParseException: DOCTYPE must be disallowed");
+		} catch (SAXParseException expected) {
+			// Rejected before &xxe; is resolved.
+		}
+	}
+
+	@Test
+	public void namespaceAwareOverloadResolvesLocalNames() throws Exception {
+		String ns = "<soap:Envelope "
+				+ "xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">"
+				+ "<soap:Body/></soap:Envelope>";
+		DocumentBuilder builder = XMLUtilities.getDocumentBuilder(true);
+		Document doc = builder.parse(new ByteArrayInputStream(ns
+				.getBytes(StandardCharsets.UTF_8)));
+		assertNotNull(doc.getDocumentElement().getLocalName());
+		assertEquals("Envelope", doc.getDocumentElement().getLocalName());
+	}
+}

--- a/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.util/src/test/resources/attacheddata-legitimate.xml
+++ b/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.util/src/test/resources/attacheddata-legitimate.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Representative Genesys GetAttachedData response; no DOCTYPE, parses fine. -->
+<userdata>
+  <key name="CustomerSegment" value="VQ_Runteam"/>
+  <key name="VH_ANI" value="2167025451"/>
+  <key name="VH_OFFER" value="1:Y"/>
+</userdata>

--- a/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.util/src/test/resources/attacheddata-xxe.xml
+++ b/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.util/src/test/resources/attacheddata-xxe.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- XXE variant: DOCTYPE + external entity. Rejected by the hardened parser. -->
+<!DOCTYPE userdata [
+  <!ENTITY xxe SYSTEM "file:///c:/windows/win.ini">
+]>
+<userdata>
+  <key name="CustomerSegment" value="&xxe;"/>
+</userdata>

--- a/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.webservices/src/main/java/org/eclipse/vtp/framework/webservices/actions/WebServiceCallAction.java
+++ b/com.vht.openvxml.framework/com.vht.openvxml.framework.plugins/org.eclipse.vtp.framework.webservices/src/main/java/org/eclipse/vtp/framework/webservices/actions/WebServiceCallAction.java
@@ -24,7 +24,6 @@ import java.util.Hashtable;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -153,16 +152,9 @@ public class WebServiceCallAction implements IAction {
 				ps.close();
 				int rc = con.getResponseCode();
 				if (rc == 200) {
-					DocumentBuilderFactory factory = DocumentBuilderFactory
-							.newInstance();
-					factory.setNamespaceAware(true);
-					factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-					factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-					factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-					factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-					factory.setXIncludeAware(false);
-					factory.setExpandEntityReferences(false);
-					DocumentBuilder builder = factory.newDocumentBuilder();
+					// Namespace-aware for the SOAP getLocalName()/NS lookups.
+					DocumentBuilder builder = XMLUtilities
+							.getDocumentBuilder(true);
 					Document document = builder.parse(con.getInputStream());
 					Element rootElement = document.getDocumentElement();
 					if (!rootElement.getLocalName().equals("Envelope")) {

--- a/com.vht.openvxml.platforms/com.vht.openvxml.platforms.plugins/com.openmethods.openvxml.platforms.genesys/src/main/java/com/openmethods/openvxml/platforms/genesys/services/GenesysVoicePlatform.java
+++ b/com.vht.openvxml.platforms/com.vht.openvxml.platforms.plugins/com.openmethods.openvxml.platforms.genesys/src/main/java/com/openmethods/openvxml/platforms/genesys/services/GenesysVoicePlatform.java
@@ -170,7 +170,11 @@ public class GenesysVoicePlatform extends VoicePlatform {
 			MetaDataRequestConfiguration configuration, IActionContext context) {
 		Map dataMap = new HashMap();
 		String attachedDataContent = context.getParameter("GetAttachedData");
-		System.out.println(attachedDataContent);
+		if (context.isDebugEnabled()) {
+			context.debug("Processing Genesys attached-data response ("
+					+ (attachedDataContent == null ? 0 : attachedDataContent
+							.length()) + " chars)");
+		}
 		try {
 			ByteArrayInputStream bais = new ByteArrayInputStream(
 					attachedDataContent.getBytes());


### PR DESCRIPTION
[//]: * (If not ready for merging, indicate the reason after the # on the next line.)
#
#### Card(s)
[//]: * (Link to the PivotalTracker or LeanKit cards.)
- [[Apiiro] Managed Semgrep - High severity finding · High Risk + 1 more](https://jira.medallia.com/browse/OPC-1507)

#### Related Pull Requests
[//]: * (List pull requests that must be merged before this one.)
- NA

#### Changes Made
1. XMLUtilities.java | Single hardened factory + `getDocumentBuilder(boolean namespaceAware)` overload; `ErrorHandler` logs DOCTYPE rejections distinctly
2. InputRequestAction, SelectionRequestAction, DataRequestAction | 6 `lastresult` parse sites rerouted through the shared factory
3. WebServiceCallAction.java | Inline hardening deleted; routed through `getDocumentBuilder(true)`
4. GenesysVoicePlatform.java | Routed through the factory; removed raw untrusted-input logging
5. XMLUtilitiesXXETest + 2 fixtures | Legit payload parses; DOCTYPE rejected; namespace overload

#### Test Procedure
[//]: * (Use Cucumber format, if possible.)
`XMLUtilitiesXXETest` (JUnit 4) run on JDK 8 in a container: **OK (3 tests)** — legitimate Genesys `<key name= value=>` payload still parses to the expected map; a DOCTYPE/external-entity payload is rejected with `SAXParseException` before the entity resolves; the namespace-aware overload resolves SOAP localnames. The run also shows the new `ErrorHandler` logging the rejection.
